### PR TITLE
Changes to URLs and configuration for 1.0 release

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,9 +4,9 @@ Priority: extra
 Maintainer: Adrian Vondendriesch <adrian.vondendriesch@credativ.de>
 Build-Depends: debhelper (>=9)
 Standards-Version: 3.9.7
-Homepage: https://github.com/pgmasters/backrest
+Homepage: http://www.pgbackrest.org/
 #Vcs-Git: git://anonscm.debian.org/collab-maint/backrest.git
-#Vcs-Browser: https://github.com/pgmasters/backrest
+#Vcs-Browser: https://github.com/pgbackrest/pgbackrest
 
 Package: pgbackrest
 Architecture: any

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,6 +1,6 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: backrest
-Source: https://github.com/pgmasters/backrest
+Source: https://github.com/pgbackrest/pgbackrest
 
 Files: *
 Copyright: 2015-2016 The PostgreSQL Global Development Group

--- a/debian/pgbackrest.conf
+++ b/debian/pgbackrest.conf
@@ -1,5 +1,5 @@
-[global:general]
+[global]
 repo-path=/var/lib/pgbackrest
 
 #[9.4-main]
-#db-path=/var/lib/postgresql/9.5/main
+#db-path=/var/lib/postgresql/9.4/main

--- a/debian/pgbackrest.dirs
+++ b/debian/pgbackrest.dirs
@@ -1,1 +1,2 @@
 /var/lib/pgbackrest
+/var/log/pgbackrest


### PR DESCRIPTION
- The project standardized on the pgBackRest name and all URLs, repos, etc. were renamed to match.
- The `global:general` section is now simply `global`.
- The default log directory is now /var/log/pgbackrest.

Note that I have not tested these changes and I'm certainly not a packaging expert.
